### PR TITLE
Change .block to .inline-block in the documentation

### DIFF
--- a/_includes/docs/layout.html
+++ b/_includes/docs/layout.html
@@ -14,7 +14,7 @@
       <tbody>
         <tr><td>.inline</td><td>display: inline</td></tr>
         <tr><td>.block</td><td>display: block</td></tr>
-        <tr><td>.block</td><td>display: inline-block</td></tr>
+        <tr><td>.inline-block</td><td>display: inline-block</td></tr>
         <tr><td>.oh</td><td>overflow: hidden</td></tr>
         <tr><td>.clearfix</td><td>Clears floated child elements</td></tr>
         <tr><td>.left</td><td>float: left</td></tr>


### PR DESCRIPTION
Current Layout Documentation

![screen shot 2014-08-03 at 2 04 37 pm](https://cloud.githubusercontent.com/assets/523933/3791376/c74ff622-1b38-11e4-8b6d-3f21bc6afbe2.png)
