### PR TITLE
Add npm start command to run default gulp task.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "fitter-happier-text": "0.0.2",
     "gulp-gzip": "0.0.8",
     "gulp-stylestats": "^0.2.7"
+  },
+  "scripts": {
+    "start": "gulp"
   }
 }


### PR DESCRIPTION
Hey @jxnblk,
Thought this might be helpful. It allows you to just run npm install . && npm start to run the project. In my opinion this makes it a little more consistent with how the node community does things and makes your project a little more agnostic to what tools you decide to use. 

You could change start to be any gulp task though.

Aces.

![](http://www.cutecatgifs.com/wp-content/uploads/2014/09/OrdinaryHonestCockatiel.gif)
