### PR TITLE
Fix links to Basics Guide

### DIFF
--- a/docs/templates/docs/utility/index.html
+++ b/docs/templates/docs/utility/index.html
@@ -94,7 +94,7 @@
       <h1>Responsive States</h1>
       <p>
         These styles allow for conditionally showing and hiding elements using a
-        <a href="/docs/guide/#media-queries">mobile-first approach</a>.
+        <a href="/docs/guides/basics/#media-queries">mobile-first approach</a>.
       </p>
       <h2>Prefix Naming Convention</h2>
       <div class="overflow-scroll">
@@ -132,7 +132,7 @@
         <span class="red bold">
           Use positions with caution. They are often unnecessary and commonly misused.
         </span><br>
-        See the <a href="/docs/guide/#positions">Guide to Basics</a> for more info.
+        See the <a href="/docs/guides/basics/#positions">Guide to Basics</a> for more info.
       </p>
       <div class="p2 bg-darken-1 rounded">
         {% include '../../../examples/positions.html' %}

--- a/docs/utility/index.html
+++ b/docs/utility/index.html
@@ -279,7 +279,7 @@
       <h1>Responsive States</h1>
       <p>
         These styles allow for conditionally showing and hiding elements using a
-        <a href="/docs/guide/#media-queries">mobile-first approach</a>.
+        <a href="/docs/guides/basics/#media-queries">mobile-first approach</a>.
       </p>
       <h2>Prefix Naming Convention</h2>
       <div class="overflow-scroll">


### PR DESCRIPTION
Came across a few links that linked to /guide instead of /guides
