### PR TITLE
#151 stop installing the next minor version of cssstats

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "clean-css": "^3.1.9",
     "css-mixed-properties": "^1.1.0",
     "cssnext": "^1.1.0",
-    "cssstats": "^2.0.1",
+    "cssstats": "~2.0.1",
     "filesize": "^3.1.2",
     "mocha": "^2.2.1",
     "postcss": "^4.1.4",


### PR DESCRIPTION
Next minor version of cssstats uses PostCSS 5.x.x which has breaking changes (all other PostCSS plugins depend on 4.x.x).

I first went down the route of upgrading all dependencies that use 4.x.x but the `cssnext` module may be deprecated in favor of `postcss-cssnext`. It seems like a lot of things are in flux still and the build is failing on postcss-cssnext so I decided to just keep it simple.