### PR TITLE
styles and readme for all optional modules that don't deal with color

### DIFF
--- a/optional_modules/background-images/README.md
+++ b/optional_modules/background-images/README.md
@@ -1,0 +1,57 @@
+
+This module controls background size and position for background images.
+
+## Background Size
+
+Use the `.bg-cover` or `.bg-contain` utilities to control background size.
+
+```html
+<div class="p4 bg-cover white bg-gray" style="background-image: url(https://d262ilb51hltx0.cloudfront.net/max/2000/1*DZwdGMaeu-rvTroJYui6Uw.jpeg)">
+  <h1>.bg-cover</h1>
+</div>
+```
+
+## Background Position
+
+Use background position utilities to control position.
+
+### .bg-center
+
+```html
+<div class="p4 bg-cover bg-center white bg-gray" style="background-image: url(https://d262ilb51hltx0.cloudfront.net/max/2000/1*DZwdGMaeu-rvTroJYui6Uw.jpeg)">
+  <h1>.bg-center</h1>
+</div>
+```
+
+### .bg-top
+
+```html
+<div class="p4 bg-cover bg-top white bg-gray" style="background-image: url(https://d262ilb51hltx0.cloudfront.net/max/2000/1*DZwdGMaeu-rvTroJYui6Uw.jpeg)">
+  <h1>.bg-top</h1>
+</div>
+```
+
+### .bg-right
+
+```html
+<div class="p4 bg-cover bg-right white bg-gray" style="background-image: url(https://d262ilb51hltx0.cloudfront.net/max/2000/1*DZwdGMaeu-rvTroJYui6Uw.jpeg)">
+  <h1>.bg-right</h1>
+</div>
+```
+
+### .bg-bottom
+
+```html
+<div class="p4 bg-cover bg-bottom white bg-gray" style="background-image: url(https://d262ilb51hltx0.cloudfront.net/max/2000/1*DZwdGMaeu-rvTroJYui6Uw.jpeg)">
+  <h1>.bg-bottom</h1>
+</div>
+```
+
+### .bg-left
+
+```html
+<div class="p4 bg-cover bg-left white bg-gray" style="background-image: url(https://d262ilb51hltx0.cloudfront.net/max/2000/1*DZwdGMaeu-rvTroJYui6Uw.jpeg)">
+  <h1>.bg-left</h1>
+</div>
+```
+

--- a/optional_modules/background-images/index.css
+++ b/optional_modules/background-images/index.css
@@ -1,0 +1,10 @@
+/* Basscss Background Images */
+
+.bg-cover   { background-size: cover }
+.bg-contain { background-size: contain }
+
+.bg-center  { background-position: center }
+.bg-top     { background-position: top }
+.bg-right   { background-position: right }
+.bg-bottom  { background-position: bottom }
+.bg-left    { background-position: left }

--- a/optional_modules/background-images/package.json
+++ b/optional_modules/background-images/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "basscss-background-images",
+  "version": "0.0.9",
+  "description": "Background image utilities module for Basscss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/basscss/basscss.git"
+  },
+  "keywords": [
+    "CSS",
+    "OOCSS",
+    "Basscss",
+    "Rework"
+  ],
+  "author": "Brent Jackson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/basscss/basscss/issues"
+  },
+  "homepage": "https://github.com/basscss/basscss",
+  "basscss": {
+    "optional": true
+  }
+}

--- a/optional_modules/btn-sizes/README.md
+++ b/optional_modules/btn-sizes/README.md
@@ -1,0 +1,13 @@
+
+These utilities extend the `basscss-btn` styles to modify button sizes.
+
+To change the line-height and padding but leave the font-size the same,
+use button size extensions.
+
+```html
+<button type="button" class="btn btn-big btn-primary mb1">Burgers</button>
+<button type="button" class="btn btn-primary mb1">Fries</button>
+<button type="button" class="btn btn-narrow btn-primary mb1">Onion Rings</button>
+<button type="button" class="btn btn-small btn-primary mb1">Shakes</button>
+```
+

--- a/optional_modules/btn-sizes/index.css
+++ b/optional_modules/btn-sizes/index.css
@@ -1,0 +1,22 @@
+/* Basscss UI Utility Button Sizes */
+
+.btn-small {
+  padding: var(--button-small-padding-y) var(--button-small-padding-x);
+}
+
+.btn-big {
+  padding: var(--button-big-padding-y) var(--button-big-padding-x);
+}
+
+.btn-narrow {
+  padding-left: var(--button-narrow-padding-x);
+  padding-right: var(--button-narrow-padding-x);
+}
+
+:root {
+  --button-small-padding-y: .25rem;
+  --button-small-padding-x: .5rem;
+  --button-big-padding-y: 1rem;
+  --button-big-padding-x: 1.25rem;
+  --button-narrow-padding-x: var(--space-1);
+}

--- a/optional_modules/btn-sizes/package.json
+++ b/optional_modules/btn-sizes/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "basscss-btn-sizes",
+  "version": "1.1.0",
+  "description": "Button size extension utilities module for Basscss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/basscss/basscss.git"
+  },
+  "keywords": [
+    "CSS",
+    "OOCSS",
+    "Basscss",
+    "Rework"
+  ],
+  "author": "Brent Jackson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/basscss/basscss/issues"
+  },
+  "homepage": "https://github.com/basscss/basscss",
+  "basscss": {
+    "optional": true
+  }
+}

--- a/optional_modules/input-range/README.md
+++ b/optional_modules/input-range/README.md
@@ -1,0 +1,10 @@
+
+This module styles base range inputs to match other form styles in Basscss.
+
+Use this with the `basscss-color-input-range` module.
+
+```html
+<input type="range" class="full-width range-light">
+<input type="range" class="full-width blue range-light">
+```
+

--- a/optional_modules/input-range/index.css
+++ b/optional_modules/input-range/index.css
@@ -1,0 +1,53 @@
+/* Basscss Input Range */
+
+input[type=range] {
+  vertical-align: middle;
+  background-color: transparent;
+  padding-top: var(--form-field-padding-y);
+  padding-bottom: var(--form-field-padding-y);
+}
+
+input[type=range]::-webkit-slider-thumb {
+  position: relative;
+  width: var(--range-thumb-width);
+  height: var(--range-thumb-height);
+  cursor: pointer;
+  margin-top: var(--range-thumb-offset);
+}
+
+/* Touch screen friendly pseudo element */
+input[type=range]::-webkit-slider-thumb:before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: calc( -.5 * var(--range-thumb-pseudo-size) + (.5 * var(--range-thumb-height)) );
+  left: calc( (-.5 * var(--range-thumb-pseudo-size)) + (.5 * var(--range-thumb-width)) );
+  width: var(--range-thumb-pseudo-size);
+  height: var(--range-thumb-pseudo-size);
+  opacity: 0;
+}
+
+input[type=range]::-moz-range-thumb {
+  width: var(--range-thumb-width);
+  height: var(--range-thumb-height);
+  cursor: pointer;
+}
+
+input[type=range]::-webkit-slider-runnable-track {
+  height: var(--range-track-height);
+  cursor: pointer;
+}
+
+input[type=range]::-moz-range-track {
+  height: var(--range-track-height);
+  cursor: pointer;
+}
+
+:root {
+  --form-field-padding-y: .5rem;
+  --range-thumb-width: var(--form-field-padding-x);
+  --range-thumb-height: calc( var(--form-field-height) - (var(--form-field-padding-y) * 2) );
+  --range-track-height: calc( var(--form-field-padding-y) / 2 );
+  --range-thumb-offset: calc( var(--range-thumb-height) / -2 + (var(--range-track-height) / 2) );
+  --range-thumb-pseudo-size: var(--form-field-height);
+}

--- a/optional_modules/input-range/package.json
+++ b/optional_modules/input-range/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "basscss-input-range",
+  "version": "2.0.0",
+  "description": "Custom input range module for Basscss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/basscss/basscss.git"
+  },
+  "keywords": [
+    "CSS",
+    "OOCSS",
+    "Basscss",
+    "Rework"
+  ],
+  "author": "Brent Jackson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/basscss/basscss/issues"
+  },
+  "homepage": "https://github.com/basscss/basscss",
+  "basscss": {
+    "optional": true
+  }
+}

--- a/optional_modules/progress/README.md
+++ b/optional_modules/progress/README.md
@@ -1,0 +1,10 @@
+
+This module styles base progress elements to better match other styles in Basscss.
+
+Use this with the `basscss-color-progress` module to style colors.
+
+```html
+<progress value="0.375">0.375</progress>
+<progress value="0.5">0.5</progress>
+```
+

--- a/optional_modules/progress/index.css
+++ b/optional_modules/progress/index.css
@@ -1,0 +1,15 @@
+/* Basscss Progress */
+
+progress {
+  display: block;
+  width: 100%;
+  height: calc( var(--form-field-height) / 4 );
+  margin: var(--form-field-padding-y) 0;
+  overflow: hidden;
+  -webkit-appearance: none;
+}
+
+:root {
+  --form-field-height: 2.25rem;
+  --form-field-padding-y: .5rem;
+}

--- a/optional_modules/progress/package.json
+++ b/optional_modules/progress/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "basscss-progress",
+  "version": "2.0.0-beta.0",
+  "description": "Custom progress element module for Basscss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/basscss/basscss.git"
+  },
+  "keywords": [
+    "css",
+    "oocss",
+    "basscss"
+  ],
+  "author": "Brent Jackson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/basscss/basscss/issues"
+  },
+  "homepage": "https://github.com/basscss/basscss",
+  "basscss": {
+    "optional": true
+  }
+}

--- a/optional_modules/responsive-margin/README.md
+++ b/optional_modules/responsive-margin/README.md
@@ -1,0 +1,54 @@
+# Basscss Responsive Margin
+
+Responsive margin utilities module for Basscss - http://basscss.com
+
+Margin utilities are based on a global white space scale defined with variables.
+These utilities use a shorthand naming convention.
+
+## Naming Convention
+
+<div class="overflow-scroll">
+  <table class="mb2 bg-darken-1 rounded table-light">
+    <thead class="bg-darken-1">
+      <tr> <th>Shorthand</th> <th>Description</th> </tr>
+    </thead>
+    <tbody>
+      <tr> <td>m</td> <td>Margin</td> </tr>
+      <tr> <td>t</td> <td>Top</td> </tr>
+      <tr> <td>r</td> <td>Right</td> </tr>
+      <tr> <td>b</td> <td>Bottom</td> </tr>
+      <tr> <td>l</td> <td>Left</td> </tr>
+      <tr> <td>x</td> <td>X-axis (left and right)</td> </tr>
+      <tr> <td>y</td> <td>Y-axis (top and bottom)</td> </tr>
+      <tr> <td>n</td> <td>Negative</td> </tr>
+      <tr> <td>1</td> <td>--space-1 (default .5rem)</td> </tr>
+      <tr> <td>2</td> <td>--space-2 (default 1rem)</td> </tr>
+      <tr> <td>3</td> <td>--space-3 (default 2rem)</td> </tr>
+      <tr> <td>4</td> <td>--space-4 (default 4rem)</td> </tr>
+    </tbody>
+  </table>
+</div>
+
+## Prefix Naming Convention
+Responsive margin utilities follow the same breakpoint prefix convention as other Basscss modules.
+
+<div class="overflow-scroll">
+  <table class="mb2 table-light overflow-hidden border rounded">
+    <thead class="bg-darken-1">
+      <tr> <th>Prefix</th> <th>Description</th> </tr>
+    </thead>
+    <tbody>
+      <tr> <td>(no prefix)</td> <td>Not scoped to a breakpoint</td> </tr>
+      <tr> <td>sm-</td> <td>--breakpoint-sm (default: min-width 40em)</td> </tr>
+      <tr> <td>md-</td> <td>--breakpoint-md (default: min-width 52em)</td> </tr>
+      <tr> <td>lg-</td> <td>--breakpoint-lg (default: min-width 64em)</td> </tr>
+    </tbody>
+  </table>
+</div>
+
+
+## Margins
+Change or reset default margins using the global white space scale.
+Negative x-axis margins are used to offset padding.
+Margin auto is used to horizontally center block-level elements with a set width.
+

--- a/optional_modules/responsive-margin/index.css
+++ b/optional_modules/responsive-margin/index.css
@@ -1,0 +1,16 @@
+/* Basscss Responsive Margin */
+
+@import "./lib/sm-margins";
+@import "./lib/md-margins";
+@import "./lib/lg-margins";
+
+@custom-media --breakpoint-sm (min-width: 40em);
+@custom-media --breakpoint-md (min-width: 52em);
+@custom-media --breakpoint-lg (min-width: 64em);
+
+:root {
+  --space-1: .5rem;
+  --space-2: 1rem;
+  --space-3: 2rem;
+  --space-4: 4rem;
+}

--- a/optional_modules/responsive-margin/lib/lg-margins.css
+++ b/optional_modules/responsive-margin/lib/lg-margins.css
@@ -1,0 +1,53 @@
+
+@media (--breakpoint-lg) {
+
+  .lg-m0  { margin:        0 }
+  .lg-mt0 { margin-top:    0 }
+  .lg-mr0 { margin-right:  0 }
+  .lg-mb0 { margin-bottom: 0 }
+  .lg-ml0 { margin-left:   0 }
+  .lg-mx0 { margin-left:   0; margin-right:  0 }
+  .lg-my0 { margin-top:    0; margin-bottom: 0 }
+
+  .lg-m1  { margin:        var(--space-1) }
+  .lg-mt1 { margin-top:    var(--space-1) }
+  .lg-mr1 { margin-right:  var(--space-1) }
+  .lg-mb1 { margin-bottom: var(--space-1) }
+  .lg-ml1 { margin-left:   var(--space-1) }
+  .lg-mx1 { margin-left:   var(--space-1); margin-right:  var(--space-1) }
+  .lg-my1 { margin-top:    var(--space-1); margin-bottom: var(--space-1) }
+
+  .lg-m2  { margin:        var(--space-2) }
+  .lg-mt2 { margin-top:    var(--space-2) }
+  .lg-mr2 { margin-right:  var(--space-2) }
+  .lg-mb2 { margin-bottom: var(--space-2) }
+  .lg-ml2 { margin-left:   var(--space-2) }
+  .lg-mx2 { margin-left:   var(--space-2); margin-right:  var(--space-2) }
+  .lg-my2 { margin-top:    var(--space-2); margin-bottom: var(--space-2) }
+
+  .lg-m3  { margin:        var(--space-3) }
+  .lg-mt3 { margin-top:    var(--space-3) }
+  .lg-mr3 { margin-right:  var(--space-3) }
+  .lg-mb3 { margin-bottom: var(--space-3) }
+  .lg-ml3 { margin-left:   var(--space-3) }
+  .lg-mx3 { margin-left:   var(--space-3); margin-right:  var(--space-3) }
+  .lg-my3 { margin-top:    var(--space-3); margin-bottom: var(--space-3) }
+
+  .lg-m4  { margin:        var(--space-4) }
+  .lg-mt4 { margin-top:    var(--space-4) }
+  .lg-mr4 { margin-right:  var(--space-4) }
+  .lg-mb4 { margin-bottom: var(--space-4) }
+  .lg-ml4 { margin-left:   var(--space-4) }
+  .lg-mx4 { margin-left:   var(--space-4); margin-right:  var(--space-4) }
+  .lg-my4 { margin-top:    var(--space-4); margin-bottom: var(--space-4) }
+
+  .lg-mxn1 { margin-left: -var(--space-1); margin-right: -var(--space-1); }
+  .lg-mxn2 { margin-left: -var(--space-2); margin-right: -var(--space-2); }
+  .lg-mxn3 { margin-left: -var(--space-3); margin-right: -var(--space-3); }
+  .lg-mxn4 { margin-left: -var(--space-4); margin-right: -var(--space-4); }
+
+  .lg-ml-auto { margin-left: auto }
+  .lg-mr-auto { margin-right: auto }
+  .lg-mx-auto { margin-left: auto; margin-right: auto; }
+
+}

--- a/optional_modules/responsive-margin/lib/md-margins.css
+++ b/optional_modules/responsive-margin/lib/md-margins.css
@@ -1,0 +1,53 @@
+
+@media (--breakpoint-md) {
+
+  .md-m0  { margin:        0 }
+  .md-mt0 { margin-top:    0 }
+  .md-mr0 { margin-right:  0 }
+  .md-mb0 { margin-bottom: 0 }
+  .md-ml0 { margin-left:   0 }
+  .md-mx0 { margin-left:   0; margin-right:  0 }
+  .md-my0 { margin-top:    0; margin-bottom: 0 }
+
+  .md-m1  { margin:        var(--space-1) }
+  .md-mt1 { margin-top:    var(--space-1) }
+  .md-mr1 { margin-right:  var(--space-1) }
+  .md-mb1 { margin-bottom: var(--space-1) }
+  .md-ml1 { margin-left:   var(--space-1) }
+  .md-mx1 { margin-left:   var(--space-1); margin-right:  var(--space-1) }
+  .md-my1 { margin-top:    var(--space-1); margin-bottom: var(--space-1) }
+
+  .md-m2  { margin:        var(--space-2) }
+  .md-mt2 { margin-top:    var(--space-2) }
+  .md-mr2 { margin-right:  var(--space-2) }
+  .md-mb2 { margin-bottom: var(--space-2) }
+  .md-ml2 { margin-left:   var(--space-2) }
+  .md-mx2 { margin-left:   var(--space-2); margin-right:  var(--space-2) }
+  .md-my2 { margin-top:    var(--space-2); margin-bottom: var(--space-2) }
+
+  .md-m3  { margin:        var(--space-3) }
+  .md-mt3 { margin-top:    var(--space-3) }
+  .md-mr3 { margin-right:  var(--space-3) }
+  .md-mb3 { margin-bottom: var(--space-3) }
+  .md-ml3 { margin-left:   var(--space-3) }
+  .md-mx3 { margin-left:   var(--space-3); margin-right:  var(--space-3) }
+  .md-my3 { margin-top:    var(--space-3); margin-bottom: var(--space-3) }
+
+  .md-m4  { margin:        var(--space-4) }
+  .md-mt4 { margin-top:    var(--space-4) }
+  .md-mr4 { margin-right:  var(--space-4) }
+  .md-mb4 { margin-bottom: var(--space-4) }
+  .md-ml4 { margin-left:   var(--space-4) }
+  .md-mx4 { margin-left:   var(--space-4); margin-right:  var(--space-4) }
+  .md-my4 { margin-top:    var(--space-4); margin-bottom: var(--space-4) }
+
+  .md-mxn1 { margin-left: -var(--space-1); margin-right: -var(--space-1); }
+  .md-mxn2 { margin-left: -var(--space-2); margin-right: -var(--space-2); }
+  .md-mxn3 { margin-left: -var(--space-3); margin-right: -var(--space-3); }
+  .md-mxn4 { margin-left: -var(--space-4); margin-right: -var(--space-4); }
+
+  .md-ml-auto { margin-left: auto }
+  .md-mr-auto { margin-right: auto }
+  .md-mx-auto { margin-left: auto; margin-right: auto; }
+
+}

--- a/optional_modules/responsive-margin/lib/sm-margins.css
+++ b/optional_modules/responsive-margin/lib/sm-margins.css
@@ -1,0 +1,53 @@
+
+@media (--breakpoint-sm) {
+
+  .sm-m0  { margin:        0 }
+  .sm-mt0 { margin-top:    0 }
+  .sm-mr0 { margin-right:  0 }
+  .sm-mb0 { margin-bottom: 0 }
+  .sm-ml0 { margin-left:   0 }
+  .sm-mx0 { margin-left:   0; margin-right:  0 }
+  .sm-my0 { margin-top:    0; margin-bottom: 0 }
+
+  .sm-m1  { margin:        var(--space-1) }
+  .sm-mt1 { margin-top:    var(--space-1) }
+  .sm-mr1 { margin-right:  var(--space-1) }
+  .sm-mb1 { margin-bottom: var(--space-1) }
+  .sm-ml1 { margin-left:   var(--space-1) }
+  .sm-mx1 { margin-left:   var(--space-1); margin-right:  var(--space-1) }
+  .sm-my1 { margin-top:    var(--space-1); margin-bottom: var(--space-1) }
+
+  .sm-m2  { margin:        var(--space-2) }
+  .sm-mt2 { margin-top:    var(--space-2) }
+  .sm-mr2 { margin-right:  var(--space-2) }
+  .sm-mb2 { margin-bottom: var(--space-2) }
+  .sm-ml2 { margin-left:   var(--space-2) }
+  .sm-mx2 { margin-left:   var(--space-2); margin-right:  var(--space-2) }
+  .sm-my2 { margin-top:    var(--space-2); margin-bottom: var(--space-2) }
+
+  .sm-m3  { margin:        var(--space-3) }
+  .sm-mt3 { margin-top:    var(--space-3) }
+  .sm-mr3 { margin-right:  var(--space-3) }
+  .sm-mb3 { margin-bottom: var(--space-3) }
+  .sm-ml3 { margin-left:   var(--space-3) }
+  .sm-mx3 { margin-left:   var(--space-3); margin-right:  var(--space-3) }
+  .sm-my3 { margin-top:    var(--space-3); margin-bottom: var(--space-3) }
+
+  .sm-m4  { margin:        var(--space-4) }
+  .sm-mt4 { margin-top:    var(--space-4) }
+  .sm-mr4 { margin-right:  var(--space-4) }
+  .sm-mb4 { margin-bottom: var(--space-4) }
+  .sm-ml4 { margin-left:   var(--space-4) }
+  .sm-mx4 { margin-left:   var(--space-4); margin-right:  var(--space-4) }
+  .sm-my4 { margin-top:    var(--space-4); margin-bottom: var(--space-4) }
+
+  .sm-mxn1 { margin-left: -var(--space-1); margin-right: -var(--space-1); }
+  .sm-mxn2 { margin-left: -var(--space-2); margin-right: -var(--space-2); }
+  .sm-mxn3 { margin-left: -var(--space-3); margin-right: -var(--space-3); }
+  .sm-mxn4 { margin-left: -var(--space-4); margin-right: -var(--space-4); }
+
+  .sm-ml-auto { margin-left: auto }
+  .sm-mr-auto { margin-right: auto }
+  .sm-mx-auto { margin-left: auto; margin-right: auto; }
+
+}

--- a/optional_modules/responsive-margin/package.json
+++ b/optional_modules/responsive-margin/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "basscss-responsive-margin",
+  "version": "0.1.0",
+  "description": "Responsive margin utilities module for Basscss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/basscss/basscss.git"
+  },
+  "keywords": [
+    "CSS",
+    "OOCSS",
+    "Basscss",
+    "Rework"
+  ],
+  "author": "Brent Jackson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/basscss/basscss/issues"
+  },
+  "homepage": "https://github.com/basscss/basscss",
+  "basscss": {
+    "optional": true
+  }
+}

--- a/optional_modules/responsive-padding/README.md
+++ b/optional_modules/responsive-padding/README.md
@@ -1,0 +1,47 @@
+# Basscss Responsive Padding
+
+Responsive padding utilities module for Basscss - http://basscss.com
+
+Padding utilities are based on a global white space scale defined with variables.
+These utilities use a shorthand naming convention.
+
+## Naming Convention
+
+<div class="overflow-scroll">
+  <table class="mb2 bg-darken-1 rounded table-light">
+    <thead class="bg-darken-1">
+      <tr> <th>Shorthand</th> <th>Description</th> </tr>
+    </thead>
+    <tbody>
+      <tr> <td>p</td> <td>Padding</td> </tr>
+      <tr> <td>t</td> <td>Top</td> </tr>
+      <tr> <td>r</td> <td>Right</td> </tr>
+      <tr> <td>b</td> <td>Bottom</td> </tr>
+      <tr> <td>l</td> <td>Left</td> </tr>
+      <tr> <td>x</td> <td>X-axis (left and right)</td> </tr>
+      <tr> <td>y</td> <td>Y-axis (top and bottom)</td> </tr>
+      <tr> <td>1</td> <td>--space-1 (default .5rem)</td> </tr>
+      <tr> <td>2</td> <td>--space-2 (default 1rem)</td> </tr>
+      <tr> <td>3</td> <td>--space-3 (default 2rem)</td> </tr>
+      <tr> <td>4</td> <td>--space-4 (default 4rem)</td> </tr>
+    </tbody>
+  </table>
+</div>
+
+## Prefix Naming Convention
+Responsive padding utilities follow the same breakpoint prefix convention as other Basscss modules.
+
+<div class="overflow-scroll">
+  <table class="mb2 table-light overflow-hidden border rounded">
+    <thead class="bg-darken-1">
+      <tr> <th>Prefix</th> <th>Description</th> </tr>
+    </thead>
+    <tbody>
+      <tr> <td>(no prefix)</td> <td>Not scoped to a breakpoint</td> </tr>
+      <tr> <td>sm-</td> <td>--breakpoint-sm (default: min-width 40em)</td> </tr>
+      <tr> <td>md-</td> <td>--breakpoint-md (default: min-width 52em)</td> </tr>
+      <tr> <td>lg-</td> <td>--breakpoint-lg (default: min-width 64em)</td> </tr>
+    </tbody>
+  </table>
+</div>
+

--- a/optional_modules/responsive-padding/index.css
+++ b/optional_modules/responsive-padding/index.css
@@ -1,0 +1,16 @@
+/* Basscss Responsive Padding */
+
+@import "./lib/sm-padding";
+@import "./lib/md-padding";
+@import "./lib/lg-padding";
+
+@custom-media --breakpoint-sm (min-width: 40em);
+@custom-media --breakpoint-md (min-width: 52em);
+@custom-media --breakpoint-lg (min-width: 64em);
+
+:root {
+  --space-1: .5rem;
+  --space-2: 1rem;
+  --space-3: 2rem;
+  --space-4: 4rem;
+}

--- a/optional_modules/responsive-padding/lib/lg-padding.css
+++ b/optional_modules/responsive-padding/lib/lg-padding.css
@@ -1,0 +1,38 @@
+
+@media (--breakpoint-lg) {
+
+  .lg-p0 { padding: 0 }
+
+  .lg-p1  { padding:        var(--space-1) }
+  .lg-pt1 { padding-top:    var(--space-1) }
+  .lg-pr1 { padding-right:  var(--space-1) }
+  .lg-pb1 { padding-bottom: var(--space-1) }
+  .lg-pl1 { padding-left:   var(--space-1) }
+  .lg-py1 { padding-top:    var(--space-1); padding-bottom: var(--space-1) }
+  .lg-px1 { padding-left:   var(--space-1); padding-right:  var(--space-1) }
+
+  .lg-p2  { padding:        var(--space-2) }
+  .lg-pt2 { padding-top:    var(--space-2) }
+  .lg-pr2 { padding-right:  var(--space-2) }
+  .lg-pb2 { padding-bottom: var(--space-2) }
+  .lg-pl2 { padding-left:   var(--space-2) }
+  .lg-py2 { padding-top:    var(--space-2); padding-bottom: var(--space-2) }
+  .lg-px2 { padding-left:   var(--space-2); padding-right:  var(--space-2) }
+
+  .lg-p3  { padding:        var(--space-3) }
+  .lg-pt3 { padding-top:    var(--space-3) }
+  .lg-pr3 { padding-right:  var(--space-3) }
+  .lg-pb3 { padding-bottom: var(--space-3) }
+  .lg-pl3 { padding-left:   var(--space-3) }
+  .lg-py3 { padding-top:    var(--space-3); padding-bottom: var(--space-3) }
+  .lg-px3 { padding-left:   var(--space-3); padding-right:  var(--space-3) }
+
+  .lg-p4  { padding:        var(--space-4) }
+  .lg-pt4 { padding-top:    var(--space-4) }
+  .lg-pr4 { padding-right:  var(--space-4) }
+  .lg-pb4 { padding-bottom: var(--space-4) }
+  .lg-pl4 { padding-left:   var(--space-4) }
+  .lg-py4 { padding-top:    var(--space-4); padding-bottom: var(--space-4) }
+  .lg-px4 { padding-left:   var(--space-4); padding-right:  var(--space-4) }
+
+}

--- a/optional_modules/responsive-padding/lib/md-padding.css
+++ b/optional_modules/responsive-padding/lib/md-padding.css
@@ -1,0 +1,38 @@
+
+@media (--breakpoint-md) {
+
+  .md-p0 { padding: 0 }
+
+  .md-p1  { padding:        var(--space-1) }
+  .md-pt1 { padding-top:    var(--space-1) }
+  .md-pr1 { padding-right:  var(--space-1) }
+  .md-pb1 { padding-bottom: var(--space-1) }
+  .md-pl1 { padding-left:   var(--space-1) }
+  .md-py1 { padding-top:    var(--space-1); padding-bottom: var(--space-1) }
+  .md-px1 { padding-left:   var(--space-1); padding-right:  var(--space-1) }
+
+  .md-p2  { padding:        var(--space-2) }
+  .md-pt2 { padding-top:    var(--space-2) }
+  .md-pr2 { padding-right:  var(--space-2) }
+  .md-pb2 { padding-bottom: var(--space-2) }
+  .md-pl2 { padding-left:   var(--space-2) }
+  .md-py2 { padding-top:    var(--space-2); padding-bottom: var(--space-2) }
+  .md-px2 { padding-left:   var(--space-2); padding-right:  var(--space-2) }
+
+  .md-p3  { padding:        var(--space-3) }
+  .md-pt3 { padding-top:    var(--space-3) }
+  .md-pr3 { padding-right:  var(--space-3) }
+  .md-pb3 { padding-bottom: var(--space-3) }
+  .md-pl3 { padding-left:   var(--space-3) }
+  .md-py3 { padding-top:    var(--space-3); padding-bottom: var(--space-3) }
+  .md-px3 { padding-left:   var(--space-3); padding-right:  var(--space-3) }
+
+  .md-p4  { padding:        var(--space-4) }
+  .md-pt4 { padding-top:    var(--space-4) }
+  .md-pr4 { padding-right:  var(--space-4) }
+  .md-pb4 { padding-bottom: var(--space-4) }
+  .md-pl4 { padding-left:   var(--space-4) }
+  .md-py4 { padding-top:    var(--space-4); padding-bottom: var(--space-4) }
+  .md-px4 { padding-left:   var(--space-4); padding-right:  var(--space-4) }
+
+}

--- a/optional_modules/responsive-padding/lib/sm-padding.css
+++ b/optional_modules/responsive-padding/lib/sm-padding.css
@@ -1,0 +1,38 @@
+
+@media (--breakpoint-sm) {
+
+  .sm-p0 { padding: 0 }
+
+  .sm-p1  { padding:        var(--space-1) }
+  .sm-pt1 { padding-top:    var(--space-1) }
+  .sm-pr1 { padding-right:  var(--space-1) }
+  .sm-pb1 { padding-bottom: var(--space-1) }
+  .sm-pl1 { padding-left:   var(--space-1) }
+  .sm-py1 { padding-top:    var(--space-1); padding-bottom: var(--space-1) }
+  .sm-px1 { padding-left:   var(--space-1); padding-right:  var(--space-1) }
+
+  .sm-p2  { padding:        var(--space-2) }
+  .sm-pt2 { padding-top:    var(--space-2) }
+  .sm-pr2 { padding-right:  var(--space-2) }
+  .sm-pb2 { padding-bottom: var(--space-2) }
+  .sm-pl2 { padding-left:   var(--space-2) }
+  .sm-py2 { padding-top:    var(--space-2); padding-bottom: var(--space-2) }
+  .sm-px2 { padding-left:   var(--space-2); padding-right:  var(--space-2) }
+
+  .sm-p3  { padding:        var(--space-3) }
+  .sm-pt3 { padding-top:    var(--space-3) }
+  .sm-pr3 { padding-right:  var(--space-3) }
+  .sm-pb3 { padding-bottom: var(--space-3) }
+  .sm-pl3 { padding-left:   var(--space-3) }
+  .sm-py3 { padding-top:    var(--space-3); padding-bottom: var(--space-3) }
+  .sm-px3 { padding-left:   var(--space-3); padding-right:  var(--space-3) }
+
+  .sm-p4  { padding:        var(--space-4) }
+  .sm-pt4 { padding-top:    var(--space-4) }
+  .sm-pr4 { padding-right:  var(--space-4) }
+  .sm-pb4 { padding-bottom: var(--space-4) }
+  .sm-pl4 { padding-left:   var(--space-4) }
+  .sm-py4 { padding-top:    var(--space-4); padding-bottom: var(--space-4) }
+  .sm-px4 { padding-left:   var(--space-4); padding-right:  var(--space-4) }
+
+}

--- a/optional_modules/responsive-padding/package.json
+++ b/optional_modules/responsive-padding/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "basscss-responsive-padding",
+  "version": "2.0.0",
+  "description": "Responsive padding utilities module for Basscss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/basscss/basscss.git"
+  },
+  "keywords": [
+    "CSS",
+    "OOCSS",
+    "Basscss",
+    "Rework"
+  ],
+  "author": "Brent Jackson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/basscss/basscss/issues"
+  },
+  "homepage": "https://github.com/basscss/basscss",
+  "basscss": {
+    "optional": true
+  }
+}

--- a/optional_modules/ui-utility-groups/README.md
+++ b/optional_modules/ui-utility-groups/README.md
@@ -1,0 +1,73 @@
+
+# Basscss UI Utility Groups
+
+UI group utilities module for Basscss - http://basscss.com
+
+Use group utilities for fine-grained control over visually grouping buttons, form fields, and other elements.
+
+## Button Groups
+Button groups allow for more flexibility in establishing gestalt and controlling information density.
+Use a combination of layout utilities and color extensions to create button groups.
+The utilities `.rounded-left`, `.rounded-right`,
+and `.not-rounded` can be used to override button and form field border radii.
+
+```html
+<div class="inline-block clearfix">
+  <button type="button" class="left button rounded-left is-active">Burgers</button>
+  <button type="button" class="left button border-left not-rounded">Fries</button>
+  <button type="button" class="left button border-left rounded-right">Shakes</button>
+</div>
+```
+
+Normally, buttons with borders would double up when placed next to each other.
+The `.x-group-item` utility adjusts negative margins and focus states to visually collapse borders.
+Functionally, this is similar to how other frameworks handle button and form input groups,
+but with more direct control over styling.
+
+```html
+<div class="inline-block clearfix">
+  <button type="button" class="left button x-group-item rounded-left">Burgers</button>
+  <button type="button" class="left button-outline x-group-item not-rounded">Fries</button>
+  <button type="button" class="left button-outline x-group-item rounded-right">Shake</button>
+</div>
+```
+
+Use `.y-group-item` to group elements vertically.
+
+```html
+<div class="inline-block">
+  <button type="button" class="block full-width button y-group-item rounded-top">Burgers</button>
+  <button type="button" class="block full-width button-outline y-group-item not-rounded">Fries</button>
+  <button type="button" class="block full-width button-outline y-group-item rounded-bottom">Shake</button>
+</div>
+```
+
+## Input Groups
+
+Input groups can be created by removing margins, adjusting border radii, and using the group utilities.
+The `.hide` utility visually hides labels, while keeping them accessible to screen readers.
+
+```html
+<form class="sm-col-6">
+  <label class="hide">Pancakes</label>
+  <input type="text" class="block full-width mb0 field-light rounded-top y-group-item" placeholder="Pancakes">
+  <label class="hide">Making</label>
+  <input type="password" class="block full-width mb0 field-light not-rounded y-group-item" placeholder="Making">
+  <label class="hide">Bacon</label>
+  <input type="text" class="block full-width field-light rounded-bottom y-group-item" placeholder="Bacon">
+  <button type="submit" class="button">Pancake</button>
+</form>
+```
+
+The grid system can be used to control button or input group widths.
+
+```html
+<form class="clearfix">
+  <label class="hide">Bacon</label>
+  <input type="text" class="col col-4 md-col-5 mb0 field-light rounded-left x-group-item" placeholder="Bacon">
+  <label class="hide">Pancakes</label>
+  <input type="password" class="col col-4 md-col-5 mb0 field-light not-rounded x-group-item" placeholder="Pancakes">
+  <button type="submit" class="col col-4 md-col-2 button rounded-right">Pancake</button>
+</form>
+```
+

--- a/optional_modules/ui-utility-groups/index.css
+++ b/optional_modules/ui-utility-groups/index.css
@@ -1,0 +1,17 @@
+/* Basscss UI Utility Groups */
+
+.x-group-item { margin-left: -var(--border-width) }
+.x-group-item:first-of-type { margin-left: 0 }
+
+.y-group-item { margin-top: -var(--border-width) }
+.y-group-item:first-of-type { margin-top: 0 }
+
+.x-group-item:focus,
+.y-group-item:focus {
+  position: relative;
+  z-index: 1;
+}
+
+:root {
+  --border-width: 1px;
+}

--- a/optional_modules/ui-utility-groups/package.json
+++ b/optional_modules/ui-utility-groups/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "basscss-ui-utility-groups",
+  "version": "1.0.1",
+  "description": "UI group utilities module for Basscss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/basscss/basscss.git"
+  },
+  "keywords": [
+    "CSS",
+    "OOCSS",
+    "Basscss",
+    "Rework"
+  ],
+  "author": "Brent Jackson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/basscss/basscss/issues"
+  },
+  "homepage": "https://github.com/basscss/basscss",
+  "basscss": {
+    "optional": true
+  }
+}

--- a/optional_modules/utility-headings/README.md
+++ b/optional_modules/utility-headings/README.md
@@ -1,0 +1,17 @@
+
+# Basscss Utility Headings
+
+<p class="hide">Responsive heading utilities module for Basscss</p>
+
+<a href="http://basscss.com" class="hide">basscss.com</a>
+
+Use `.h0` and `.h00` to create headings larger than the default h1.
+Add `.h0-responsive` or `h00-responsive` to use vw based sizes at larger viewports.
+Adjust the width of the browser to see the difference.
+
+```html
+<h1 class="h00 h00-responsive">Hamburger 00</h1>
+<h1 class="h0 h0-responsive">Hamburger 0</h1>
+<h1 class="h1 h1-responsive">Hamburger 1</h1>
+```
+

--- a/optional_modules/utility-headings/index.css
+++ b/optional_modules/utility-headings/index.css
@@ -1,0 +1,30 @@
+/* Basscss Utility Headings */
+
+.h00 { font-size: var(--h00) }
+.h0 {  font-size: var(--h0) }
+
+@media (--breakpoint-md) {
+  .h00-responsive { font-size: var(--h00-responsive) }
+  .h0-responsive {  font-size: var(--h0-responsive) }
+  .h1-responsive {  font-size: var(--h1-responsive) }
+}
+
+@media (--breakpoint-xl) {
+  .h00-responsive { font-size: var(--h00-responsive-max) }
+  .h0-responsive {  font-size: var(--h0-responsive-max) }
+  .h1-responsive {  font-size: var(--h1-responsive-max) }
+}
+
+@custom-media --breakpoint-md (min-width: 52em);
+@custom-media --breakpoint-xl (min-width: 96em);
+
+:root {
+  --h00:    4rem;
+  --h0:     3rem;
+  --h00-responsive: 8vw;
+  --h0-responsive:  6vw;
+  --h1-responsive:  4vw;
+  --h00-responsive-max: 7.68rem;
+  --h0-responsive-max:  5.76rem;
+  --h1-responsive-max:  3.84rem;
+}

--- a/optional_modules/utility-headings/package.json
+++ b/optional_modules/utility-headings/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "basscss-utility-headings",
+  "version": "0.0.6",
+  "description": "Responsive heading utilities module for Basscss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/basscss/basscss.git"
+  },
+  "keywords": [
+    "CSS",
+    "OOCSS",
+    "Basscss",
+    "Rework"
+  ],
+  "author": "Brent Jackson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/basscss/basscss/issues"
+  },
+  "homepage": "https://github.com/basscss/basscss",
+  "basscss": {
+    "optional": true
+  }
+}


### PR DESCRIPTION
v8 branch PR

Created a new `optional_modules` dir with styles and readme files copied from their individual repositories.

- The four optional modules that deal w/ color are not included here because of your new direction w/ color:
  - `border-colors`
  - `color-input-range`
  - `color-progress`
  - `highlight`

- The `responsive-white-space` module was separated into margin and padding mods, and the original readme was adjusted accordingly for each mod.

- All custom properties are now local to each module.