### PR TITLE
use default parameters from es6 in add-element util

### DIFF
--- a/test/util/add-element.js
+++ b/test/util/add-element.js
@@ -1,11 +1,7 @@
 
-const addElement = (el, parent) => {
+export default const addElement = (el, parent = document.body) => {
   const $el = document.createElement(el)
-  parent = parent || document.body
   parent.appendChild($el)
   $el.computedStyle = window.getComputedStyle($el)
   return $el
 }
-
-export default addElement
-


### PR DESCRIPTION
use default parameters from es6 on `parent = document.body` from `add-element` util.