### PR TITLE
Preserve custom properties

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -14,7 +14,10 @@ module.exports = {
     'postcss-reporter'
   ],
   input: 'src/basscss.css',
-  dir: 'css'
+  dir: 'css',
+  'postcss-custom-properties': {
+    preserve: true
+  }
 }
 
 


### PR DESCRIPTION
This PR preserves custom property values. Specially useful now that [browser support](http://caniuse.com/#feat=css-variables) is finally 🌱.

Fixes #186