### PR TITLE
Fix negative margins

### DIFF
--- a/modules/margin/index.css
+++ b/modules/margin/index.css
@@ -40,10 +40,10 @@
 .mx4 { margin-left:   var(--space-4); margin-right:  var(--space-4) }
 .my4 { margin-top:    var(--space-4); margin-bottom: var(--space-4) }
 
-.mxn1 { margin-left: -var(--space-1); margin-right: -var(--space-1); }
-.mxn2 { margin-left: -var(--space-2); margin-right: -var(--space-2); }
-.mxn3 { margin-left: -var(--space-3); margin-right: -var(--space-3); }
-.mxn4 { margin-left: -var(--space-4); margin-right: -var(--space-4); }
+.mxn1 { margin-left: calc(var(--space-1) * -1); margin-right: calc(var(--space-1) * -1); }
+.mxn2 { margin-left: calc(var(--space-2) * -1); margin-right: calc(var(--space-2) * -1); }
+.mxn3 { margin-left: calc(var(--space-3) * -1); margin-right: calc(var(--space-3) * -1); }
+.mxn4 { margin-left: calc(var(--space-4) * -1); margin-right: calc(var(--space-4) * -1); }
 
 .m-auto  { margin: auto; }
 .mt-auto { margin-top: auto }

--- a/test/margin.spec.js
+++ b/test/margin.spec.js
@@ -202,6 +202,29 @@ describe('margin', () => {
     })
   })
 
+  describe('negative', () => {
+    it('should set margin-left and margin-right to -8px', () => {
+      div.className = 'mxn1'
+      expect(div.computedStyle.marginLeft).to.equal('-8px')
+      expect(div.computedStyle.marginRight).to.equal('-8px')
+    })
+    it('should set margin-left and margin-right to -16px', () => {
+      div.className = 'mxn2'
+      expect(div.computedStyle.marginLeft).to.equal('-16px')
+      expect(div.computedStyle.marginRight).to.equal('-16px')
+    })
+    it('should set margin-left and margin-right to -32px', () => {
+      div.className = 'mxn3'
+      expect(div.computedStyle.marginLeft).to.equal('-32px')
+      expect(div.computedStyle.marginRight).to.equal('-32px')
+    })
+    it('should set margin-left and margin-right to -64px', () => {
+      div.className = 'mxn4'
+      expect(div.computedStyle.marginLeft).to.equal('-64px')
+      expect(div.computedStyle.marginRight).to.equal('-64px')
+    })
+  })
+
   describe('auto', () => {
     it('should set margin-top, margin-right, margin-bottom, and margin-left auto')
     it('should set margin-left auto')


### PR DESCRIPTION
The current negative margin utilities do not conform to the [spec](https://drafts.csswg.org/css-variables/), as noted in #224. This just updates them to use `calc()`, which seems to be the recommended way, and means [`postcss-custom-properties`](https://github.com/postcss/postcss-custom-properties) and browsers can deal with them. 