### PR TITLE
Don't preserve custom properties

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,13 +1,13 @@
 module.exports = {
   plugins: [
-    'postcss-import',
-    'postcss-custom-media',
-    'postcss-custom-properties',
-    'postcss-calc',
-    'cssstats',
-    'postcss-discard-comments',
-    'postcss-remove-root',
-    'autoprefixer',
-    'postcss-reporter'
-  ].map(require)
+    require('postcss-import'),
+    require('postcss-custom-media'),
+    require('postcss-custom-properties')({ preserve: false }),
+    require('postcss-calc'),
+    require('cssstats'),
+    require('postcss-discard-comments'),
+    require('postcss-remove-root'),
+    require('autoprefixer'),
+    require('postcss-reporter')
+  ]
 }


### PR DESCRIPTION
`postcss-custom-properties` changed the default behavior to preserve the custom-properties in v7: https://github.com/postcss/postcss-custom-properties/releases/tag/7.0.0

Looks like this plugin was updated in this commit: https://github.com/basscss/basscss/commit/048ceb90fce0f0350111e0518d99aa455628b536

With the remove-root plugin, this means that the final output uses the custom-properties, but the definitions are stripped out, meaning that the css doesn't actually work.

Another option would have been to remove the `postcss-remove-root` plugin, but that would mean shipping custom properties that might conflict with other users' css files, which I assume is why it's there in the first place.

This solves: https://github.com/basscss/basscss/issues/257

Let me know if you want any other changes.