### PR TITLE
Fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - 10
 addons:
   firefox: '42.0'
+services:
+  - xvfb
 before_script:
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
[![Build Status](https://travis-ci.org/gnclmorais/basscss.svg?branch=fix-travisci-build)](https://travis-ci.org/gnclmorais/basscss)

I’ve noticed [`master` is failing](https://travis-ci.org/github/basscss/basscss/builds/671704947), so this is a simple fix for the TravisCI flow. Inspired by https://stackoverflow.com/a/55674747/590525. You can see the successful build at https://travis-ci.org/github/gnclmorais/basscss/builds/753148919.